### PR TITLE
Trim digit printed from floats.

### DIFF
--- a/src/openscad_poly/context.py
+++ b/src/openscad_poly/context.py
@@ -1,6 +1,10 @@
 from math import *
 import sys
 
+class pfloat(float):
+    def __repr__(self):
+      return "%0.3f" % self
+
 class OSCADPolyContext:
     def __init__(self, file):
       self.file = file
@@ -17,5 +21,5 @@ class OSCADPolyContext:
         print "    );}"
 
     def add_poly(self, id, points, paths):
-      self.polygons.append({ 'id': id, 'points':points, 'paths':paths})
-
+      newpoints = [[pfloat(x), pfloat(y)] for x, y in points]
+      self.polygons.append({ 'id': id, 'points':newpoints, 'paths':paths})


### PR DESCRIPTION
First pull request on github.

Method generate of OSCADPolyContext in context.py would format floats…
… with an excessive of sig figs. float is subclassed to produce pfloat that limits **repr** output to 3 digits after decimal.

Saw this request on your repo and wanted it myself so I added.

Let me know if you think there is a better way of doing it.

Patrick Wheeler
